### PR TITLE
Upgrade gradle to 2.8 to fix build with newer android studio

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.8-all.zip


### PR DESCRIPTION
I upgraded Android Studio to 1.5 and I was getting a gradle build error when running `clean`. This fixes it for me.
